### PR TITLE
Genomics QA fixes and VCF-info change

### DIFF
--- a/input/fsh/EX_Disease.fsh
+++ b/input/fsh/EX_Disease.fsh
@@ -2,7 +2,7 @@ Instance: excluded-disease
 InstanceOf: Disease
 Description: "Phenopacket Example for an excluded disease"
 * id = "id.disease.1"
-* clinicalStatus = $sct#315215002 "Disorder excluded (situation)"
+* clinicalStatus = $ClinStatus#active "Active"
 * code  = $sct#87628006  "Bacterial infectious disease"
 * subject = Reference(example-patient)
 

--- a/input/fsh/EX_RD_Phenopacket.fsh
+++ b/input/fsh/EX_RD_Phenopacket.fsh
@@ -3,12 +3,11 @@ InstanceOf: Phenopacket
 Description: "Example use case for a child with undiagnosed developmental delay"
 * identifier.value = "id.treatment.1"
 * status = #preliminary "preliminary"
-* type = $LOINC#LOINC_11516-2 "Physician Episode of care medical records"
+* type = $LOINC#11516-2 "Physician Episode of care medical records"
 * date = "2018-03-16"
 * title = "Phenopacket (static snapshot of clinical findings to support differential diagnosis of a child with developmental delay)."
 * author = Reference(PeterGeneticist)
 * subject = Reference(Proband1)
-* section[diseases].entry[0] = Reference(intellectualDisabilityDisease)
 * section[phenotypic_features].entry[+] = Reference(longPhiltrum)
 * section[phenotypic_features].entry[+] = Reference(microphthalmia)
 * section[phenotypic_features].entry[+] = Reference(retinalDetachment)
@@ -21,6 +20,7 @@ Description: "Example use case for a child with undiagnosed developmental delay"
 * section[phenotypic_features].entry[+] = Reference(amyotrophy)
 * section[phenotypic_features].entry[+] = Reference(fiberSizeVariability)
 * section[biosamples].entry[+] = Reference(muscleBiopsy)
+* section[diseases].entry[0] = Reference(intellectualDisabilityDisease)
 
 
 
@@ -75,6 +75,15 @@ Description: "Reduced visual acuity (HP:0007663)"
 * status = #final "final"
 * subject = Reference(Proband1)
 * code = $hpo#HP:0007663 "Reduced visual acuity"
+* valueCodeableConcept = $LOINC#LA9633-4 "Present"
+
+Instance: lowSetEars
+InstanceOf: PhenotypicFeature
+Description: "Low-set ears (HP:0000369)"
+* id = "hp.0000369"
+* status = #final "final"
+* subject = Reference(Proband1)
+* code = $hpo#HP:0000369 "Reduced visual acuity"
 * valueCodeableConcept = $LOINC#LA9633-4 "Present"
 
 Instance: hypotonia 
@@ -173,7 +182,7 @@ Description: "Biosample Example -- muscle biopsy"
 //* type =  $efo#EFO_0010942 "primary tumor sample"
 * subject = Reference(Proband1)
 * identifier.value = "arbitrary identifier"
-* extension[MaterialSample].valueCoding = $efo#EFO_0009655 "abnormal sample"
+* extension[MaterialSample].valueCodeableConcept = $efo#EFO_0009655 "abnormal sample"
 * processing.procedure = $ncit#NCIT_C51895 "Muscle Biopsy"
 * collection.collectedDateTime = "2021-01-20"
 

--- a/input/fsh/Phenopackets-Genomics-Extensions.fsh
+++ b/input/fsh/Phenopackets-Genomics-Extensions.fsh
@@ -18,7 +18,7 @@ Extension: PhredQualityScore
 Id: phred-quality-score
 Title: "Phred Quality Score"
 Description: "Used to include Phred-scaled quality score for the assertion made in ALT."
-* value[x] only integer // Do you prefer another FHIR data type? // make it a floating point 
+* value[x] only Quantity // Do you prefer another FHIR data type? // make it a floating point 
 
 // Declaring an extension for the filter status
 Extension: FilterStatus

--- a/input/fsh/Phenopackets-Genomics-Instances.fsh
+++ b/input/fsh/Phenopackets-Genomics-Instances.fsh
@@ -8,6 +8,7 @@ Description: "This is an example of phenopackets-genomic-interpretation
               and VariantInterpretation building blocks."
 //* id = "111.111.111.111"
 * subject = Reference(phenopacketPatientExample01)  
+* valueCodeableConcept = LNC#LA9633-4 "Present" 
 // component[gene-studied]
 * component[gene-studied].valueCodeableConcept.coding = HGNC#HGNC:3477 "ETF1"
 //Place-holder for alternateIds

--- a/input/fsh/Phenopackets-Genomics-Profiles.fsh
+++ b/input/fsh/Phenopackets-Genomics-Profiles.fsh
@@ -149,9 +149,9 @@ component[allelic-state] MS // SU
 * extension contains
     MoleculeContext named moleculeContext  1..1 // VariationDescriptor.molecule_context
 //* extension[acmgPathogenicity] ^defaultValue[x] only CodeableConcept
-* extension[acmgPathogenicity] ^defaultValueCodeableConcept = PPAPC#0 "NOT_PROVIDED"
+//* extension[acmgPathogenicity] ^defaultValueCodeableConcept = PPAPC#0 "NOT_PROVIDED"
 //* extension[therapeuticActionability] ^defaultValue[x] only CodeableConcept
-* extension[therapeuticActionability] ^defaultValueCodeableConcept = PPTA#0  "UNKNOWN_ACTIONABILITY"
+//* extension[therapeuticActionability] ^defaultValueCodeableConcept = PPTA#0  "UNKNOWN_ACTIONABILITY"
 //VariationDescriptor
 * component[amino-acid-chg] 0..1 //protein variations
 * component[genomic-dna-chg] 0..1 //genomic variations, structural variants
@@ -194,7 +194,7 @@ component[allelic-state] MS // SU
 //VariationDescriptor.alternate_labels is represented above as part of component[variation-code].valueCodeable
 //VariationDescriptor.molecule_context is represented above as part of extension
 //* extension[moleculeContext] ^defaultValue[x] only CodeableConcept
-* extension[moleculeContext] ^defaultValueCodeableConcept = PPMC#0  "unspecified_molecule_context" //molecule_context
+//* extension[moleculeContext] ^defaultValueCodeableConcept = PPMC#0  "unspecified_molecule_context" //molecule_context
 * extension[moleculeContext] obeys phenopackets-moleculeContext-align-with-result-component
 * component[functional-annotation].valueCodeableConcept from SequenceOntologyStructuralVariantVS (extensible) //structural_type
 //VariationDescriptor.vrs_ref_allele_seq is represented above as part of component[ref-allele] and it is 1..1

--- a/input/fsh/Phenopackets-Genomics-Profiles.fsh
+++ b/input/fsh/Phenopackets-Genomics-Profiles.fsh
@@ -137,8 +137,7 @@ component[allelic-state] MS // SU
 //* component:genomic-ref-seq 0..1 // may be used to formally identify ref-sequence
 * component[alt-allele] 1..1 // alt. Is it really one alternative allele?
 * component[alt-allele].extension contains PhredQualityScore named phredQualityScore 0..1
-//place holder for VcfRecord.info element. More discussions are needed.
-* component[alt-allele].extension contains VCFInfo named vcfInfo 0..1 //VcfRecord
+
 //VariantInterpretation
 * extension contains
     AcmgPathogenicityClassification named acmgPathogenicity 1..1
@@ -146,6 +145,8 @@ component[allelic-state] MS // SU
     TherapeuticActionability named therapeuticActionability 1..1
 * extension contains
     VrsObject named vrsObject  1..1 // Variation as VRS
+//place holder for VcfRecord.info element. More discussions are needed.
+* extension contains VCFInfo named vcfInfo 0..1 //VcfRecord
 * extension contains
     MoleculeContext named moleculeContext  1..1 // VariationDescriptor.molecule_context
 //* extension[acmgPathogenicity] ^defaultValue[x] only CodeableConcept

--- a/input/fsh/Phenopackets-Genomics-Profiles.fsh
+++ b/input/fsh/Phenopackets-Genomics-Profiles.fsh
@@ -49,8 +49,8 @@ component[allelic-state] MS // SU
 // * effectiveDateTime 0..0
 // * issued 0..0
 // * performer 0..0
-* valueCodeableConcept = LNC#LA9633-4 "Present" /*This is 1..1 element value[x] in parent profile as 
-                                    1..1 and we selected #Present as a fixed value.*/
+//* valueCodeableConcept = LNC#LA9633-4 "Present" 
+/*This is 1..1 element value[x] in parent profile as 1..1 and we selected #Present as a fixed value.*/
 // * dataAbsentReason 0..0
 // * note 0..0
 // bodysite 0..0 //There are two elements of the same name, i.e., bodySite


### PR DESCRIPTION
QA fixes and moving VCF-Info up in the structure of the variant profile to be a direct child of the variant profile.